### PR TITLE
Migrate to kramdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+
+matrix:
+  allow_failures:
+    - rvm: jruby-9.2.7.0
+
 rvm:
   - 2.3.8
   - 2.4.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - jruby-9.2.7.0
 
 before_install:
   - gem install bundler:2.0.2

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -68,7 +68,7 @@ PATH=$(pwd)/ronn-ng/bin:$PATH
 The following gems are required for ronn-ng development:
  * nokogiri
  * mustache
- * rdiscount
+ * kramdown
  * rubocop
  * sinatra
  * rack
@@ -76,7 +76,7 @@ The following gems are required for ronn-ng development:
  * test-unit
 
 ```
-gem install nokogiri mustache rdiscount rubocop sinatra rack rake test-unit
+gem install nokogiri mustache kramdown rubocop sinatra rack rake test-unit
 ```
 
 Or install them with bundler using the project's gem definition:

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :environment do
   $LOAD_PATH.unshift ROOTDIR unless $LOAD_PATH.include?(ROOTDIR)
   $LOAD_PATH.unshift LIBDIR unless $LOAD_PATH.include?(LIBDIR)
   require_library 'nokogiri'
-  require_library 'rdiscount'
+  require_library 'kramdown'
   ENV['RUBYLIB'] = $LOAD_PATH.join(':')
   ENV['PATH'] = "#{BINDIR}:#{ENV['PATH']}"
 end

--- a/bin/ronn
+++ b/bin/ronn
@@ -48,7 +48,7 @@ end
 # Libraries and LOAD_PATH shenanigans
 
 begin
-  require 'rdiscount'
+  require 'kramdown'
   require 'nokogiri'
   require 'ronn'
 rescue LoadError => e

--- a/ronn-ng.gemspec
+++ b/ronn-ng.gemspec
@@ -111,9 +111,9 @@ Gem::Specification.new do |s|
   s.test_files = s.files.select { |path| path =~ /^test\/.*_test.rb/ }
 
   s.extra_rdoc_files = %w[LICENSE.txt AUTHORS]
+  s.add_dependency 'kramdown',    '~> 2.1'
   s.add_dependency 'mustache',    '~> 0.7', '>= 0.7.0'
   s.add_dependency 'nokogiri',    '~> 1.9', '>= 1.9.0'
-  s.add_dependency 'rdiscount',   '~> 2.0', '>= 2.0.7'
   s.add_development_dependency 'rack',      '~> 2.0',  '>= 2.0.6'
   s.add_development_dependency 'rake',      '~> 12.3', '>= 12.3.0'
   s.add_development_dependency 'rubocop',   '~> 0.60', '>= 0.57.1'

--- a/test/angle_bracket_syntax.html
+++ b/test/angle_bracket_syntax.html
@@ -13,5 +13,5 @@ code block,
 
 <p>or when <code>&lt;WORD&gt;</code> is enclosed in backticks.</p>
 
-<p>or when <var>WORD</var> has a &lt;dot.&gt; or &lt;foo:colon&gt;.</p>
+<p>or when <var>WORD</var> has a <dot.> or <colon>.</colon></dot.></p>
 </div>

--- a/test/definition_list_syntax.html
+++ b/test/definition_list_syntax.html
@@ -13,9 +13,9 @@
 <dd>The definition may span
 multiple lines and even
 
-<p>start</p>
+    <p>start</p>
 
-<p>new paragraphs</p>
+    <p>new paragraphs</p>
 </dd>
 <dt>
 <code>--somearg</code>=<var>VALUE</var>

--- a/test/entity_encoding_test.html
+++ b/test/entity_encoding_test.html
@@ -15,19 +15,18 @@
 <p>Here's some special entities:</p>
 
 <ul>
-<li>&amp;bull;       •</li>
-<li>&amp;nbsp;        </li>
-<li>&amp;copy;       ©</li>
-<li>&amp;rdquo;      ”</li>
-<li>&amp;mdash;      —</li>
-<li>&amp;reg;        ®</li>
-<li>&amp;sect;       §</li>
-<li>&amp;ge;         ≥</li>
-<li>&amp;le;         ≤</li>
-<li>&amp;ne;         ≠</li>
-<li>&amp;equiv;      ≡</li>
+  <li>&amp;bull;       •</li>
+  <li>&amp;nbsp;        </li>
+  <li>&amp;copy;       ©</li>
+  <li>&amp;rdquo;      ”</li>
+  <li>&amp;mdash;      —</li>
+  <li>&amp;reg;        ®</li>
+  <li>&amp;sect;       §</li>
+  <li>&amp;ge;         ≥</li>
+  <li>&amp;le;         ≤</li>
+  <li>&amp;ne;         ≠</li>
+  <li>&amp;equiv;      ≡</li>
 </ul>
-
 
 <p>Here's a line that uses non-breaking spaces to force the
 last few words to wrap together.</p>

--- a/test/markdown_syntax.html
+++ b/test/markdown_syntax.html
@@ -602,15 +602,14 @@ on a line by itself:</p>
 <p>That is:</p>
 
 <ul>
-<li>Square brackets containing the link identifier (optionally
+  <li>Square brackets containing the link identifier (optionally
 indented from the left margin using up to three spaces);</li>
-<li>followed by a colon;</li>
-<li>followed by one or more spaces (or tabs);</li>
-<li>followed by the URL for the link;</li>
-<li>optionally followed by a title attribute for the link, enclosed
+  <li>followed by a colon;</li>
+  <li>followed by one or more spaces (or tabs);</li>
+  <li>followed by the URL for the link;</li>
+  <li>optionally followed by a title attribute for the link, enclosed
 in double or single quotes, or enclosed in parentheses.</li>
 </ul>
-
 
 <p>The following three link definitions are equivalent:</p>
 
@@ -853,14 +852,13 @@ for links, allowing for two styles: <em>inline</em> and <em>reference</em>.</p>
 <p>That is:</p>
 
 <ul>
-<li>An exclamation mark: <code>!</code>;</li>
-<li>followed by a set of square brackets, containing the <code>alt</code>
+  <li>An exclamation mark: <code>!</code>;</li>
+  <li>followed by a set of square brackets, containing the <code>alt</code>
 attribute text for the image;</li>
-<li>followed by a set of parentheses, containing the URL or path to
+  <li>followed by a set of parentheses, containing the URL or path to
 the image, and an optional <code>title</code> attribute enclosed in double
 or single quotes.</li>
 </ul>
-
 
 <p>Reference-style image syntax looks like this:</p>
 

--- a/test/nested_list_with_code.html
+++ b/test/nested_list_with_code.html
@@ -2,14 +2,13 @@
 
 <h1 id="a-1-">a(1)</h1>
 <ul>
-<li>
+  <li>
 <code>toggle_status</code>
-
-<ul>
-<li>Toggle the display of the status bar.</li>
-</ul>
-</li>
-<li>
+    <ul>
+      <li>Toggle the display of the status bar.</li>
+    </ul>
+  </li>
+  <li>
 <code>spawn &lt;executable&gt; &lt;additional args&gt;</code> TODO explain path-alike expansion</li>
 </ul>
 </div>

--- a/test/ordered_list.html
+++ b/test/ordered_list.html
@@ -6,25 +6,23 @@
 <h3 id="One-item-list">One-item list</h3>
 
 <ol>
-<li>Hello, world!</li>
+  <li>Hello, world!</li>
 </ol>
-
 
 <h3 id="Three-item-list">Three-item list</h3>
 
 <ol>
-<li>Hello, world!</li>
-<li>Item 2</li>
-<li>Item 3</li>
+  <li>Hello, world!</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
 </ol>
-
 
 <h3 id="Four-item-list-with-all-1s">Four-item list with all 1s</h3>
 
 <ol>
-<li>Item 1</li>
-<li>Item 2</li>
-<li>Item 3</li>
-<li>Item 4</li>
+  <li>Item 1</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
+  <li>Item 4</li>
 </ol>
 </div>


### PR DESCRIPTION
Fixes #27.

I'd like to migrate the markdown parser to kramdown, so that jruby is automatically supported.