### PR TITLE
Add usage strings for --name and --section

### DIFF
--- a/bin/ronn
+++ b/bin/ronn
@@ -22,7 +22,9 @@
 # / Document attributes:
 # /       --date=<date>          published date in YYYY-MM-DD format (bottom-center)
 # /       --manual=<name>        name of the manual (top-center)
+# /       --name=<name>          title of the manual page (top-left, top-right, bottom-right)
 # /       --organization=<name>  publishing group or individual (bottom-left)
+# /       --section=<sec>        section of the manual page (with name)
 # /
 # / Misc options:
 # /   -w, --warnings            show troff warnings on stderr


### PR DESCRIPTION
These two command line options exist, and work, but are not documented in the `--help` output.