### PR TITLE
Fix regex encoding: don't assume Windows-31J encoding

### DIFF
--- a/lib/ronn/roff.rb
+++ b/lib/ronn/roff.rb
@@ -351,7 +351,7 @@ module Ronn
     def write(text)
       return if text.nil? || text.empty?
       # lines cannot start with a '.'. insert zero-width character before.
-      text = text.gsub(/\n\\\./s, "\n\\\\&\\.")
+      text = text.gsub(/\n\\\./, "\n\\\\&\\.")
       buf_ends_in_newline = @buf.last && @buf.last[-1] == "\n"
       @buf << '\&' if text[0, 2] == '\.' && buf_ends_in_newline
       @buf << text


### PR DESCRIPTION
As [documented](https://apidock.com/ruby/Regexp), using the regex flag `s` implies that the source string encoding is assumed to be Windows-31J. This prevents `ronn` from compiling valid UTF-8 sources (which actually use Unicode characters and aren't just plain ASCII), reporting the following exception:

    /var/lib/gems/2.3.0/gems/ronn-ng-0.8.2/lib/ronn/roff.rb:354:in `gsub': incompatible encoding regexp match (Windows-31J regexp with UTF-8 string) (Encoding::CompatibilityError)

This PR fixes the issue by removing the unneeded flag, which was probably introduced by accident in https://github.com/apjanke/ronn-ng/commit/3dca20cff6b0305a4248d711a17cdd4a51c94557#diff-8c2a2b56f00218c211ba4fc3ed93077cR358

I hope this helps, let me know.