### PR TITLE
Support only mustache 1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ronn-ng (0.9.1)
       kramdown (~> 2.1)
-      mustache (~> 0.7, >= 0.7.0)
+      mustache (~> 1.0)
       nokogiri (~> 1.9, >= 1.9.0)
 
 GEM
@@ -13,9 +13,9 @@ GEM
     jaro_winkler (1.5.3)
     kramdown (2.1.0)
     mini_portile2 (2.4.0)
-    mustache (0.99.8)
+    mustache (1.1.1)
     mustermann (1.0.3)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)

--- a/ronn-ng.gemspec
+++ b/ronn-ng.gemspec
@@ -111,7 +111,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[LICENSE.txt AUTHORS]
   s.add_dependency 'kramdown',    '~> 2.1'
-  s.add_dependency 'mustache',    '~> 0.7', '>= 0.7.0'
+  s.add_dependency 'mustache',    '~> 1.0'
   s.add_dependency 'nokogiri',    '~> 1.9', '>= 1.9.0'
   s.add_development_dependency 'rack',      '~> 2.0',  '>= 2.0.6'
   s.add_development_dependency 'rake',      '~> 12.3', '>= 12.3.0'


### PR DESCRIPTION
The old `ronn` gem, [supported mustache versions higher that 1.0](https://rubygems.org/gems/ronn/versions/0.7.3/dependencies). However, [the current `ronn-ng` version does not](https://rubygems.org/gems/ronn-ng/versions/0.9.1/dependencies).

I tried running tests using mustache 1, and they run just fine, so I believe not allowing mustache 1 was done unintentionally in b21765c230397a01b5a762eb5a272328685e2782.

Normally, I would restore the original `ronn` constraint (`>= 0.7.0`), but since mustache 1.0 was release back in 2015, I figured it could be a good opportunity to drop support for old mustache versions too.

Just let me know which option you prefer and I'll update the PR.