### PR TITLE
Revert `\(bu` to `\[ci]` change

### DIFF
--- a/lib/ronn/roff.rb
+++ b/lib/ronn/roff.rb
@@ -168,7 +168,7 @@ module Ronn
           when 'ol'
             macro 'IP', %W["#{node.parent.children.index(node) + 1}." 4]
           when 'ul'
-            macro 'IP', ['"\\[ci]"', '4']
+            macro 'IP', ['"\(bu"', '4']
           else
             raise "List element found as a child of non-list parent element: #{node.inspect}"
           end
@@ -316,7 +316,7 @@ module Ronn
     end
 
     HTML_ROFF_ENTITIES = {
-      '•' => '\[ci]',
+      '•' => '\(bu',
       '&lt;' => '<',
       '&gt;' => '>',
       ' ' => '\~', # That's a literal non-breaking space character there

--- a/test/entity_encoding_test.roff
+++ b/test/entity_encoding_test.roff
@@ -13,27 +13,27 @@ Your output <i>might</i> look like this:
 .IP "" 0
 .P
 Here\'s some special entities:
-.IP "\[ci]" 4
-&bull; \[ci]
-.IP "\[ci]" 4
+.IP "\(bu" 4
+&bull; \(bu
+.IP "\(bu" 4
 &nbsp; \~
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &copy; \(co
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &rdquo; \(rs
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &mdash; \(em
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &reg; \(rg
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &sect; \(sc
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &ge; \(>=
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &le; \(<=
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &ne; \(!=
-.IP "\[ci]" 4
+.IP "\(bu" 4
 &equiv; \(==
 .IP "" 0
 .P

--- a/test/markdown_syntax.roff
+++ b/test/markdown_syntax.roff
@@ -553,15 +553,15 @@ Then, anywhere in the document, you define your link label like this, on a line 
 .IP "" 0
 .P
 That is:
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Square brackets containing the link identifier (optionally indented from the left margin using up to three spaces);
-.IP "\[ci]" 4
+.IP "\(bu" 4
 followed by a colon;
-.IP "\[ci]" 4
+.IP "\(bu" 4
 followed by one or more spaces (or tabs);
-.IP "\[ci]" 4
+.IP "\(bu" 4
 followed by the URL for the link;
-.IP "\[ci]" 4
+.IP "\(bu" 4
 optionally followed by a title attribute for the link, enclosed in double or single quotes, or enclosed in parentheses\.
 .IP "" 0
 .P
@@ -813,11 +813,11 @@ Inline image syntax looks like this:
 .IP "" 0
 .P
 That is:
-.IP "\[ci]" 4
+.IP "\(bu" 4
 An exclamation mark: \fB!\fR;
-.IP "\[ci]" 4
+.IP "\(bu" 4
 followed by a set of square brackets, containing the \fBalt\fR attribute text for the image;
-.IP "\[ci]" 4
+.IP "\(bu" 4
 followed by a set of parentheses, containing the URL or path to the image, and an optional \fBtitle\fR attribute enclosed in double or single quotes\.
 .IP "" 0
 .P

--- a/test/nested_list_with_code.roff
+++ b/test/nested_list_with_code.roff
@@ -1,11 +1,11 @@
 .TH "NESTED_LIST_WITH_CODE" "" "January 1979" ""
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fBtoggle_status\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Toggle the display of the status bar\.
 .IP "" 0
 
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fBspawn <executable> <additional args>\fR TODO explain path\-alike expansion
 .IP "" 0
 


### PR DESCRIPTION
This reverts commit e7df1f0d254836f6ac7760a2727b4bd342d52ecb, reversing changes made to c3fd67e94094e3e366e958d746c68c2903756294.

Commit was introduced as a aesthetic change when using `-Kutf8 -Tutf8` in https://github.com/rtomayko/ronn/pull/71, which closed ronn issue https://github.com/rtomayko/ronn/issues/70.

Quoting from the issue that led to the PR:

> This may seem a little strange, it's more aesthetic then anything
> else. When troff is run with -Kutf8 -Tutf8 to ensure that utf8
> characters appear correctly then the bullets generated by \(bu appear as
> small squares (I'm using 13pt Pragmata Pro).

However, in `bundler` we're not using `-Tutf8`, but `-Tascii`, and this results in weird characters for list items as reported [here](https://github.com/cli-kit/cli-command/issues/78).

Since this change never made it into any `ronn` release, I think reverting it could encourage adoption of `ronn-ng` as a drop-in replacement of `ronn`. At least for us :)