### PR TITLE
Revert "Revert "allow both HTML and HTML fragment" because it broke the test suite" and fix tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Version 0.10.1 (in progress)
 * Revert `\[ci]` back to `\(bu)` (<https://github.com/apjanke/ronn-ng/pull/51>)
 * Minor fix to single-quote escaping (<https://github.com/apjanke/ronn-ng/issues/55>)
 * Elide HTML comments when producing roff output (<https://github.com/apjanke/ronn-ng/issues/65>)
+* Allow outputting both HTML doc and HTML fragment in one run (<https://github.com/apjanke/ronn-ng/issues/60>)
 * Bump to mustache 1.x
 
 Version 0.10.0 (never)

--- a/bin/ronn
+++ b/bin/ronn
@@ -162,7 +162,6 @@ elsif build
   formats ||= %w[roff html]
 end
 formats ||= []
-formats.delete('html') if formats.include?('html_fragment')
 
 options['date'] &&= Date.strptime(options['date'], '%Y-%m-%d')
 options['styles'] = styles

--- a/test/test_ronn.rb
+++ b/test/test_ronn.rb
@@ -86,7 +86,7 @@ class RonnTest < Test::Unit::TestCase
 
     wrong = dest + '.wrong'
     test File.basename(source, '.ronn') + ' HTML' do
-      output = `ronn --pipe --html --fragment #{source}`
+      output = `ronn --pipe --fragment #{source}`
       expected = begin
         File.read(dest)
       rescue IOError


### PR DESCRIPTION
Well, it doesn't fix tests, but it makes the errors the same as without it, so

Closes #60
Ref: #61