### PR TITLE
Permit `Time` class loading from YAML.

### DIFF
--- a/test/test_ronn_document.rb
+++ b/test/test_ronn_document.rb
@@ -16,7 +16,7 @@ class DocumentTest < Test::Unit::TestCase
     # Check if `permitted_classes` keyword argument is available. That means
     # `safe_load` is the default loading mechanism, i.e. Ruby 3.1 + Psych 4.0
     # are used.
-    kwargs = !(YAML.method(:load).parameters & [[:key, :permitted_classes]]).empty?
+    kwargs = !(YAML.method(:load).parameters & [%i[key permitted_classes]]).empty?
     if kwargs
       YAML.load(yaml, permitted_classes: [Time])
     else

--- a/test/test_ronn_document.rb
+++ b/test/test_ronn_document.rb
@@ -146,7 +146,7 @@ class DocumentTest < Test::Unit::TestCase
                      'toc'          => [['NAME', 'NAME']],
                      'organization' => nil,
                      'manual'       => nil
-                   }, YAML.load(@doc.to_yaml))
+                   }, YAML.load(@doc.to_yaml, permitted_classes: [Time]))
     end
 
     test 'converting to json' do

--- a/test/test_ronn_document.rb
+++ b/test/test_ronn_document.rb
@@ -137,6 +137,15 @@ class DocumentTest < Test::Unit::TestCase
 
     test 'converting to yaml' do
       require 'yaml'
+      # Check if `permitted_classes` keyword argument is available. That means
+      # `safe_load` is the default loading mechanism, i.e. Ruby 3.1 + Psych 4.0
+      # are used.
+      kwargs = !(YAML.method(:load).parameters & [[:key, :permitted_classes]]).empty?
+      loaded_yaml = if kwargs
+        YAML.load(@doc.to_yaml, permitted_classes: [Time])
+      else
+        YAML.load(@doc.to_yaml)
+      end
       assert_equal({
                      'section'      => '1',
                      'name'         => 'hello',
@@ -146,7 +155,7 @@ class DocumentTest < Test::Unit::TestCase
                      'toc'          => [['NAME', 'NAME']],
                      'organization' => nil,
                      'manual'       => nil
-                   }, YAML.load(@doc.to_yaml, permitted_classes: [Time]))
+                   }, loaded_yaml)
     end
 
     test 'converting to json' do


### PR DESCRIPTION
Since Psych 4.0, the `safe_load` is used as default loading mechanism. There are just a few permitted classes and `Time` is not one of them [[1]]. This results it test failure:

~~~
Error: test_converting_to_yaml(DocumentTest::TestSimpleConventionallyNamedDocument): Psych::DisallowedClass: Tried to load unspecified class: Time
~~~

Please also note that in YAML specs 1.2, the `timestamp` is not listed as supported tag anymore [[2]].

Given that:

1) ronn-ng does not provide any supported way of loading the serialized YAML.
2) The `to_yaml` does not appear to be used internally/externally anywhere.
3) If there were users of this functionality, it would have been already know, reported and fixed at this moment.

The best course of action is fixing the test case by listing the `Time` as valid class for parsing.

Fixes #80

[1]: https://docs.ruby-lang.org/en/master/Psych.html#method-c-safe_load
[2]: https://github.com/yaml/yaml-spec/issues/268