### PR TITLE
Use valid charset in Content-Type in HTML output

### DIFF
--- a/lib/ronn/template/default.html
+++ b/lib/ronn/template/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta http-equiv='content-type' content='text/html;charset=utf-8'>
   <meta name='generator' content='{{ generator }}'>
   <title>{{ title }}</title>
   {{{ stylesheet_tags }}}


### PR DESCRIPTION
See ISO 10646:2017 etc.

This PR ports the fix at https://github.com/n-ronn/nronn/pull/27 from @tnir to the `ronn-ng` repo.