### PR TITLE
[tests] require fileutils explicitly

### DIFF
--- a/test/test_ronn.rb
+++ b/test/test_ronn.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'contest'
 
 class RonnTest < Test::Unit::TestCase


### PR DESCRIPTION
ruby 3.4 no longer loads fileutils implicitly.
Fixes #124 .